### PR TITLE
memcpy() is defined in <cstring>

### DIFF
--- a/sodium.cc
+++ b/sodium.cc
@@ -10,6 +10,7 @@
 
 #include <cstdlib>
 #include <ctime>
+#include <cstring>
 #include <string>
 #include <sstream>
 


### PR DESCRIPTION
I need this to compile on a new Ubuntu 12.04 system with gcc/g++ 4.8 installed.
