### PR TITLE
Handle crypto_secretbox_open errors.

### DIFF
--- a/lib/secretbox.js
+++ b/lib/secretbox.js
@@ -145,7 +145,7 @@ module.exports  = function SecretBox(secretKey, encoding) {
             self.boxKey.get()
         );
 
-        if( encoding ) {
+        if( plainText && encoding ) {
             return plainText.toString(encoding);
         }
 


### PR DESCRIPTION
In case binding.crypto_secretbox_open failed, plainText will be undefined.
