### PR TITLE
Create Local handle for new Buffers to avoid GC

### DIFF
--- a/sodium.cc
+++ b/sodium.cc
@@ -39,7 +39,8 @@ Local<Function> bufferConstructor =
 // Create a new buffer, and get a pointer to it
 #define NEW_BUFFER_AND_PTR(name, size) \
     Buffer* name = Buffer::New(size); \
-    unsigned char* name ## _ptr = (unsigned char*)Buffer::Data(name)
+    Local<Object> name ## _handle = Local<Object>::New(name->handle_); \
+    unsigned char* name ## _ptr = (unsigned char*)Buffer::Data(name ## _handle)
 
 #define GET_ARG_AS(i, NAME, TYPE) \
     ARG_IS_BUFFER(i,#NAME); \


### PR DESCRIPTION
fixes #19

The lack of a `Local` handle inside the `HandleScope` where the new `Buffer` objects are being created means that the GC can kick in while you're still working on them and clean up the handles that were originally created for them. This change introduces explicit handles each time you `Buffer::New()` which will automatically be assigned to the `HandleScope` in use.
