### PR TITLE
Don't set the secret key to the public key.

### DIFF
--- a/lib/keys/keypair.js
+++ b/lib/keys/keypair.js
@@ -186,10 +186,7 @@ module.exports = function KeyPair() {
     };
 
     self.setPublicKey = function(key, encoding) {
-        if( key instanceof KeyPair ) {
-            self.publicKey = key.pk();
-        }
-        else if( key instanceof CryptoBaseBuffer ) {
+        if( key instanceof CryptoBaseBuffer ) {
             if( key.size() == self.publicKeySize ) {
                 self.publicKey = key;
             }
@@ -205,10 +202,7 @@ module.exports = function KeyPair() {
     };
 
     self.setSecretKey = function(key, encoding) {
-        if( key instanceof KeyPair ) {
-            self.secretKey = key.pk();
-        }
-        else if( key instanceof CryptoBaseBuffer ) {
+        if( key instanceof CryptoBaseBuffer ) {
             if( key.size() == self.secretKeySize ) {
                 self.secretKey = key;
             }


### PR DESCRIPTION
The setSecretKey function copied the public key into the secret key.  This probably means that the code has never been used or tested, so I removed it.
