### PR TITLE
Added sodium.Key.SignKey.fromSeed(seed, encoding)

### DIFF
--- a/docs/low-level-api.md
+++ b/docs/low-level-api.md
@@ -1015,7 +1015,7 @@ Decrypts a cipher text `ctxt` given the receivers given a `nonce` and the partia
 
 ## crypto_sign_keypair()
 
-Generates a random signing key pair with a secret key and corresponding public key. Returns an object as with two buffers as follows:
+Generates a random signing key pair with a secret key and corresponding public key. Returns an object with two buffers as follows:
 
 **Returns**:
 
@@ -1035,6 +1035,40 @@ Generates a random signing key pair with a secret key and corresponding public k
 
 ```javascript
 var bobKeys = sodium.crypto_sign_keypair();
+```
+
+## crypto_sign_seed_keypair(seed)
+
+Deterministically generates a signing key pair with a secret key and
+corresponding public key. The signing key pair is used for signing and contains
+the seed, in fact the only secret is the seed the other parts of the signing key
+always be reconstructed from the seed using this method. Hence, you only have
+to save the seed in your configuration file, database or where you store keys.
+
+**Parameters**:
+
+  * **Buffer** `message` to sign
+  * **Buffer** `seed` to generate signing key pair from. **Must** be `crypto_sign_SEEDBYTES` in length
+
+**Returns**:
+
+  * **{Object}** `keypair` with public and secret keys
+
+        { secretKey: <secret key buffer>,
+          publicKey: <public key buffer> }
+
+  * `undefined` in case or error
+
+**Key lengths**:
+
+  * `secretKey` is `crypto_sign_SECRETKEYBYTES` bytes in length
+  * `publicKey` is `crypto_sign_PUBLICKEYBYTES` bytes in length
+
+**Example**:
+
+```javascript
+var seed = new buffer('zSX0jgvyyaw8n+Z/Iv6lS7EI9pS7aesQUgxIsihjXfA=', 'base64');
+var aliceKeys = sodium.crypto_sign_seed_keypair(seed);
 ```
 
      

--- a/lib/keys/sign-key.js
+++ b/lib/keys/sign-key.js
@@ -4,6 +4,7 @@
 var util = require('util');
 var binding = require('../../build/Release/sodium');
 var KeyPair = require('./keypair');
+var toBuffer = require('../toBuffer');
 
 var Sign = function SignKey(publicKey, secretKey, encoding) {
     var self = this;
@@ -33,4 +34,14 @@ var Sign = function SignKey(publicKey, secretKey, encoding) {
     }
 };
 util.inherits(Sign, KeyPair);
+
+Sign.fromSeed = function(seed, encoding) {
+    encoding = String(encoding) || 'utf8';
+
+    var buf = toBuffer(seed, encoding);
+
+    var keys = binding.crypto_sign_seed_keypair(buf);
+    return new Sign(keys.publicKey, keys.secretKey, undefined);
+};
+
 module.exports = Sign;

--- a/test/test_sign.js
+++ b/test/test_sign.js
@@ -5,8 +5,10 @@ var should = require('should');
 var sodium = require('../build/Release/sodium');
 
 var Sign = require('../lib/sign');
+var SignKey = require('../lib/keys/sign-key');
 if (process.env.COVERAGE) {
     Sign = require('../lib-cov/sign');
+    SignKey = require('../lib-cov/keys/sign-key');
 }
 
 describe("Sign", function () {
@@ -14,6 +16,32 @@ describe("Sign", function () {
         var sign = new Sign();
         var message = new Buffer("This is a test", 'utf8');
         var signedMsg = sign.sign("This is a test", 'utf8');
+        var checkMsg = Sign.verify(signedMsg);
+        checkMsg.toString('utf8').should.eql("This is a test");
+        done();
+    });
+    it("sign/verify with existing key", function(done) {
+        var key = new SignKey(
+            'DsWygyoTcB7/NT5OqRzT0eaFf+6bJBSSBRfDOyU3x9k=',
+            'Aav6yqemxoPNNqxeKJXMlruKxXEHLD931S8pXzxt4mkO' +
+            'xbKDKhNwHv81Pk6pHNPR5oV/7pskFJIFF8M7JTfH2Q==',
+            'base64');
+        var sign = new Sign(key);
+        var message = new Buffer("This is a test", 'utf8');
+        var signedMsg = sign.sign("This is a test", 'utf8');
+        signedMsg.publicKey.toString('base64').should.eql(
+            'DsWygyoTcB7/NT5OqRzT0eaFf+6bJBSSBRfDOyU3x9k=');
+        var checkMsg = Sign.verify(signedMsg);
+        checkMsg.toString('utf8').should.eql("This is a test");
+        done();
+    });
+    it("sign/verify with key from seed", function(done) {
+        var key = new SignKey.fromSeed('Aav6yqemxoPNNqxeKJXMlruKxXEHLD931S8pXzxt4mk=', 'base64');
+        var sign = new Sign(key);
+        var message = new Buffer("This is a test", 'utf8');
+        var signedMsg = sign.sign("This is a test", 'utf8');
+        signedMsg.publicKey.toString('base64').should.eql(
+            'DsWygyoTcB7/NT5OqRzT0eaFf+6bJBSSBRfDOyU3x9k=');
         var checkMsg = Sign.verify(signedMsg);
         checkMsg.toString('utf8').should.eql("This is a test");
         done();


### PR DESCRIPTION
Summary more or less speaks for itself... IMO the seed is the key, I want to use this to secure REST APIs, and distributing a 44 char base64 api-key is more, fun than a 88 char base64 api-key... :)

I also took the liberty of adding a test with hardcoded key, so that we test that keys can be loaded..
Along with a test for fromSeed()... I used the javascript port of tweetnacl to generated the hardcoded keys and seed. So that should show some interoperability. Sanity checks are always good :)

By the way, any plans to merge detached signing from #11? If the fork is merge worthy can we at least add detached signing? Personally I hate to cut it out of the buffer...