### PR TITLE
`make configure` before install

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "node-gyp": ">=1.0.2"
     },
     "scripts":{
+        "preinstall": "make configure",
         "test": "make test"
     },
     "repository" : {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "node-gyp": ">=1.0.2"
     },
     "scripts":{
-        "preinstall": "make configure",
+        "preinstall": "make sodium",
         "test": "make test"
     },
     "repository" : {


### PR DESCRIPTION
without `make configure` preinstall script entry, develop branch fails to install under io.js 1.3.0 and presumably other node.js platforms.