### PR TITLE
Use node's assert module instead of should.js for runtime assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 # node-sodium
 
+Uses Libsodium 1.0.3
 
 Port of the [lib sodium](https://github.com/jedisct1/libsodium) Encryption Library to Node.js.
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -4,7 +4,7 @@
 var binding = require('../build/Release/sodium');
 var AuthKey = require('./keys/auth-key');
 var toBuffer = require('./toBuffer');
-var should = require('should');
+var assert = require('assert');
 
 /**
  * Message Authentication
@@ -42,7 +42,7 @@ module.exports = function  Auth(secretKey, encoding) {
 
     // Init key
     self.secretKey = new AuthKey(secretKey, encoding);
-    
+
     /** Size of the authentication token */
     self.bytes = function () {
         return binding.crypto_auth_BYTES;
@@ -66,7 +66,7 @@ module.exports = function  Auth(secretKey, encoding) {
      * @param {String} encoding  encoding to use
      */
     self.setEncoding = function(encoding) {
-        encoding.should.have.type('string').match(/^(?:utf8|ascii|binary|hex|utf16le|ucs2|base64)$/);
+        assert(!!encoding.match(/^(?:utf8|ascii|binary|hex|utf16le|ucs2|base64)$/), 'Encoding ' + encoding + ' is currently unsupported.');
         self.defaultEncoding = encoding;
     };
 

--- a/lib/box.js
+++ b/lib/box.js
@@ -10,7 +10,7 @@ var binding = require('../build/Release/sodium');
 var toBuffer = require('./toBuffer');
 var BoxKey = require('./keys/box-key');
 var Nonce = require('./nonces/box-nonce');
-var should = require('should');
+var assert = require('assert');
 
 /**
  * Public-key authenticated encryption: Box
@@ -30,7 +30,7 @@ module.exports = function Box(publicKey, secretKey, easy) {
 
     /** Set of keys used to encrypt and decrypt messages */
     self.boxKey = new BoxKey(publicKey, secretKey);
-    
+
     /** Set mode to regular or easy */
     self.easy = easy || false;
 
@@ -78,7 +78,7 @@ module.exports = function Box(publicKey, secretKey, easy) {
      * @param {String} encoding  encoding to use
      */
     self.setEncoding = function(encoding) {
-        encoding.should.have.type('string').match(/^(?:utf8|ascii|binary|hex|utf16le|ucs2|base64)$/);
+        assert(!!encoding.match(/^(?:utf8|ascii|binary|hex|utf16le|ucs2|base64)$/), 'Encoding ' + encoding + ' is currently unsupported.');
         self.defaultEncoding = encoding;
     };
 
@@ -147,8 +147,8 @@ module.exports = function Box(publicKey, secretKey, easy) {
     self.decrypt = function (cipherBox, encoding) {
         encoding = String(encoding || self.defaultEncoding);
 
-        cipherBox.should.have.type('object').properties('cipherText', 'nonce');
-        cipherBox.cipherText.should.be.an.instanceof.Buffer;
+        assert(typeof cipherBox == 'object' && cipherBox.hasOwnProperty('cipherText') && cipherBox.hasOwnProperty('nonce'), 'cipherBox is an object with properties `cipherText` and `nonce`.');
+        assert(cipherBox.cipherText instanceof Buffer, 'cipherBox should have a cipherText property that is a buffer') ;
 
         var nonce = new Nonce(cipherBox.nonce);
 

--- a/lib/crypto-base-buffer.js
+++ b/lib/crypto-base-buffer.js
@@ -4,8 +4,8 @@
  /* jslint node: true */
 'use strict';
 
+var assert = require('assert');
 var binding = require('../build/Release/sodium');
-var should = require('should');
 var toBuffer = require('./toBuffer');
 
 module.exports =  function CryptoBaseBuffer() {
@@ -44,13 +44,13 @@ module.exports =  function CryptoBaseBuffer() {
     self.init = function(options) {
         options = options || {};
 
-        options.expectedSize.should.have.type('number').above(0);
-        
+        assert(typeof options.expectedSize == 'number' && options.expectedSize > 0, 'options.expectedSize > 0');
+
         if ( !options.type ) {
             throw self.error('type must be passed to init');
         }
-        options.type.should.have.type('string');
-        
+        assert(typeof options.type == 'string');
+
         self.type = options.type;
 
         if ( !options.expectedSize ) {
@@ -71,7 +71,8 @@ module.exports =  function CryptoBaseBuffer() {
      * @param {String} encoding  encoding to use
      */
     self.setEncoding = function(encoding) {
-        encoding.should.have.type('string').match(self.validEncodings);
+        assert(typeof encoding == 'string');
+        assert(encoding.match(self.validEncodings));
         self.defaultEncoding = encoding;
     };
 
@@ -105,7 +106,7 @@ module.exports =  function CryptoBaseBuffer() {
         if( !encList ) {
             return;
         }
-        encList.should.be.instanceof(Array);
+        assert(encList instanceof Array);
         var rxStr = '^(?:';
         var l = encList.length;
         for(var i=0; i < l; i++) {
@@ -153,7 +154,7 @@ module.exports =  function CryptoBaseBuffer() {
     self.size = function() {
         return self.expectedSize;
     };
-    
+
     /**
      * Get the length of the buffer
      * @returns {number} length in bytes of the buffer
@@ -186,7 +187,7 @@ module.exports =  function CryptoBaseBuffer() {
             return Buffer.byteLength(value, encoding) == self.expectedSize;
         }
 
-        if( typeof value == 'object' ) { 
+        if( typeof value == 'object' ) {
             if( value instanceof Array || value instanceof Buffer ) {
                 return value.length == self.expectedSize;
             }

--- a/lib/ecdh.js
+++ b/lib/ecdh.js
@@ -9,7 +9,6 @@
 'use strict';
 
 var binding = require('../build/Release/sodium');
-var should = require('should');
 var DHKey = require('./keys/dh-key');
 
 module.exports = function ECDH(publicKey, secretKey) {

--- a/lib/onetime-auth.js
+++ b/lib/onetime-auth.js
@@ -1,8 +1,8 @@
 /* jslint node: true */
 'use strict';
 
+var assert = require('assert');
 var binding = require('../build/Release/sodium');
-var should = require('should');
 var OneTimeKey = require('./keys/onetime-key');
 var toBuffer = require('./toBuffer');
 
@@ -26,12 +26,12 @@ module.exports = function OneTimeAuth(secretKey, encoding) {
 
     // Init key
     self.secretKey = new OneTimeKey(secretKey, encoding);
-    
+
     /** Size of the authentication token */
     self.bytes = function() {
         return binding.crypto_onetimeauth_BYTES;
     };
-    
+
     /** String name of the default crypto primitive used in onetimeauth operations */
     self.primitive = function() {
         return binding.crypto_onetimeauth_PRIMITIVE;
@@ -50,7 +50,7 @@ module.exports = function OneTimeAuth(secretKey, encoding) {
      * @param {String} encoding  encoding to use
      */
     self.setEncoding = function(encoding) {
-        encoding.should.have.type('string').match(/^(?:utf8|ascii|binary|hex|utf16le|ucs2|base64)$/);
+        assert(!!encoding.match(/^(?:utf8|ascii|binary|hex|utf16le|ucs2|base64)$/), 'Encoding ' + encoding + ' is currently unsupported.');
         self.defaultEncoding = encoding;
     };
 

--- a/lib/secretbox.js
+++ b/lib/secretbox.js
@@ -7,7 +7,7 @@
 'use strict';
 
 var binding = require('../build/Release/sodium');
-var should = require('should');
+var assert = require('assert');
 var toBuffer = require('./toBuffer');
 var SecretBoxKey = require('./keys/secretbox-key');
 var Nonce = require('./nonces/secretbox-nonce');
@@ -64,7 +64,7 @@ module.exports  = function SecretBox(secretKey, encoding) {
      * @param {String} encoding  encoding to use
      */
     self.setEncoding = function(encoding) {
-        encoding.should.have.type('string').match(/^(?:utf8|ascii|binary|hex|utf16le|ucs2|base64)$/);
+        assert(!!encoding.match(/^(?:utf8|ascii|binary|hex|utf16le|ucs2|base64)$/), 'Encoding ' + encoding + ' is currently unsupported.');
         self.defaultEncoding = encoding;
     };
 
@@ -133,9 +133,9 @@ module.exports  = function SecretBox(secretKey, encoding) {
     self.decrypt = function (cipherBox, encoding) {
         encoding = String(encoding || self.defaultEncoding);
 
-        cipherBox.should.have.type('object').properties('cipherText', 'nonce');
-        cipherBox.cipherText.should.be.an.instanceof.Buffer;
-        cipherBox.nonce.should.be.an.instanceof.Buffer;
+        assert(typeof cipherBox == 'object' && cipherBox.hasOwnProperty('cipherText') && cipherBox.hasOwnProperty('nonce'), 'cipherBox is an object with properties `cipherText` and `nonce`.');
+        assert(cipherBox.cipherText instanceof Buffer, 'cipherBox should have a cipherText property that is a buffer') ;
+        assert(cipherBox.nonce instanceof Buffer, 'cipherBox should have a nonce property that is a buffer') ;
 
         var nonce = new Nonce(cipherBox.nonce);
 

--- a/lib/sign.js
+++ b/lib/sign.js
@@ -7,6 +7,7 @@
 'use strict';
 
 var binding = require('../build/Release/sodium');
+var assert = require('assert');
 var SignKey = require('./keys/sign-key');
 var toBuffer = require('./toBuffer');
 
@@ -64,7 +65,7 @@ function Sign(key) {
      * @param {String} encoding  encoding to use
      */
     self.setEncoding = function(encoding) {
-        encoding.should.have.type('string').match(/^(?:utf8|ascii|binary|hex|utf16le|ucs2|base64)$/);
+        assert(!!encoding.match(/^(?:utf8|ascii|binary|hex|utf16le|ucs2|base64)$/), 'Encoding ' + encoding + ' is currently unsupported.');
         self.defaultEncoding = encoding;
     };
 
@@ -131,7 +132,7 @@ function Sign(key) {
  * @param {Buffer|String|Array} cipherText  the signed message
  */
 Sign.verify = function (signature) {
-    signature.should.have.type('object').with.properties('sign', 'publicKey');
+    assert(typeof signature == 'object' && signature.hasOwnProperty('sign') && signature.hasOwnProperty('publicKey'));
     return binding.crypto_sign_open(signature.sign, signature.publicKey);
 };
 
@@ -144,7 +145,7 @@ Sign.verify = function (signature) {
  * returns true if verified successfully, false otherwise.
  */
 Sign.verifyDetached = function (signature, message) {
-    signature.should.have.type('object').with.properties('sign', 'publicKey');
+    assert(typeof signature == 'object' && signature.hasOwnProperty('sign') && signature.hasOwnProperty('publicKey'));
     return binding.crypto_sign_verify_detached(signature.sign, message, signature.publicKey);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,33 +1,42 @@
 {
-    "name": "sodium",
-    "version": "1.0.17",
-    "author" : "Pedro Paixao <paixaop@gmail.com>",
-    "license" : "MIT",
-    "description" : "Lib Sodium port for node.js",
-    "dependencies": {
-        "should" : ">=2.1.0",
-         "nan": ">=1.6.2"
-    },
-    "devDependencies": {
-        "mocha"  : ">=0.14.1",
-        "mocha-istanbul" : ">=0.2.0",
-        "istanbul" : ">=0.2.6",
-        "node-gyp": ">=1.0.2"
-    },
-    "scripts":{
-        "test": "make test",
-        "preinstall": "make",
-        "install": "node-gyp rebuild"
-    },
-    "repository" : {
-        "type" : "git",
-        "url" : "https://github.com/paixaop/node-sodium"
-    },
-    "keywords":["encryption", "ed25519", "curve25519",
-        "NaCl", "libsodium", "crypto",
-        "unique", "stamp"],
-    "licenses": [{
-        "type": "MIT",
-        "url": "http://opensource.org/licenses/mit-license.php"
-    }]
+  "name": "sodium",
+  "version": "1.0.17",
+  "author": "Pedro Paixao <paixaop@gmail.com>",
+  "license": "MIT",
+  "description": "Lib Sodium port for node.js",
+  "dependencies": {
+    "nan": ">=1.6.2"
+  },
+  "devDependencies": {
+    "istanbul": ">=0.2.6",
+    "mocha": ">=0.14.1",
+    "mocha-istanbul": ">=0.2.0",
+    "node-gyp": ">=1.0.2",
+    "should": ">=2.1.0"
+  },
+  "scripts": {
+    "test": "make test",
+    "preinstall": "make",
+    "install": "node-gyp rebuild"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paixaop/node-sodium"
+  },
+  "keywords": [
+    "encryption",
+    "ed25519",
+    "curve25519",
+    "NaCl",
+    "libsodium",
+    "crypto",
+    "unique",
+    "stamp"
+  ],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://opensource.org/licenses/mit-license.php"
+    }
+  ]
 }

--- a/test/test_auth.js
+++ b/test/test_auth.js
@@ -76,4 +76,17 @@ describe("Auth", function () {
             auth.validate("123123", "123123");
         }).should.throw();
     });
+
+    it('should set an encoding if a supported encoding is passed to setEncoding', function() {
+        var auth = new Auth();
+        auth.setEncoding('base64');
+        auth.defaultEncoding.should.equal('base64');
+    });
+
+    it('should fail to set an encoding if an unsupported encoding is passed to setEncoding', function() {
+        var auth = new Auth();
+        (function () {
+            auth.setEncoding('unsupported-encoding');
+        }).should.throw();
+    });
 });

--- a/test/test_box.js
+++ b/test/test_box.js
@@ -28,6 +28,34 @@ describe("Box", function () {
         done();
     });
 
+    it("encrypt should throw if no first argument", function () {
+        var box = new Box();
+        (function() {
+            box.decrypt();
+        }).should.throw();
+    });
+
+    it("encrypt should throw if the first argument is not an object with `cipherText` and `nonce` properties", function () {
+        var box = new Box();
+        (function() {
+            box.decrypt({});
+        }).should.throw();
+        (function() {
+            box.decrypt({cipherText: new Buffer('foo')});
+        }).should.throw();
+        (function() {
+            box.decrypt({nonce: 'bar'});
+        }).should.throw();
+    });
+
+    it("encrypt show throw if cipherBox.cipherText is not a buffer", function () {
+        var box = new Box();
+        (function() {
+            box.decrypt({cipherText: "not a buffer", nonce: "foo"});
+        }).should.throw();
+    });
+
+
     it("key size should match that of sodium", function (done) {
         var box = new Box();
         box.key().getPublicKey().size().should.eql(sodium.crypto_box_PUBLICKEYBYTES);
@@ -87,4 +115,16 @@ describe("Box", function () {
         done();
     });
 
+    it('should set an encoding if a supported encoding is passed to setEncoding', function() {
+        var box = new Box();
+        box.setEncoding('base64');
+        box.defaultEncoding.should.equal('base64');
+    });
+
+    it('should fail to set an encoding if an unsupported encoding is passed to setEncoding', function() {
+        var box = new Box();
+        (function () {
+            box.setEncoding('unsupported-encoding');
+        }).should.throw();
+    });
 });


### PR DESCRIPTION
should.js modifies Object.prototype, and so making it a non-dev dependency will break the tests on apps that use another `should` for their testing, like the one chai provides. This replaces all of the `should` calls in node-sodium with their `assert` equivalents and makes should.js a dev dependency.