### PR TITLE
require should.js and it as a dependency

### DIFF
--- a/lib/toBuffer.js
+++ b/lib/toBuffer.js
@@ -1,3 +1,4 @@
+var should = require('should');
 /**
  * toBuffer Module
  * Convert value into a buffer

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "description": "Lib Sodium port for node.js",
   "dependencies": {
-    "nan": ">=1.6.2"
+    "nan": ">=1.6.2",
+    "should": "^7.0.2"
   },
   "devDependencies": {
     "istanbul": ">=0.2.6",


### PR DESCRIPTION
Alternatively, we need to remove the line in toBuffer that uses `should`