### PR TITLE
use ^ compatible ranges, not open ended >= ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
   "license": "MIT",
   "description": "Lib Sodium port for node.js",
   "dependencies": {
-    "nan": ">=1.6.2"
+    "nan": "^1.6.2"
   },
   "devDependencies": {
-    "istanbul": ">=0.2.6",
-    "mocha": ">=0.14.1",
-    "mocha-istanbul": ">=0.2.0",
-    "node-gyp": ">=1.0.2",
-    "should": ">=2.1.0"
+    "istanbul": "^0.2.6",
+    "mocha": "^0.14.1",
+    "mocha-istanbul": "^0.2.0",
+    "node-gyp": "^1.0.2",
+    "should": "^2.1.0"
   },
   "scripts": {
     "test": "make test",


### PR DESCRIPTION
[nan](https://www.npmjs.com/package/nan) just recently published a breaking change (a total rewrite) as 2.0.0
This broke node-sodium, because it was using open ended version ranges.
That is a bad idea, because it makes it easy for modules you depend on to break your code.
The solution is to use ^ ranges, which mean "compatible" ^ ranges will give you new patches, new features but not breaking changes.
