### PR TITLE
disable autogen.sh, so libtool and automake are not required

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BINDIR = ./node_modules/.bin
 LIBSODIUM_DIR = ./deps/libsodium
 
 configure:
-	@cd $(LIBSODIUM_DIR)/ && ./autogen.sh
+  #@cd $(LIBSODIUM_DIR)/ && ./autogen.sh
 	@cd $(LIBSODIUM_DIR)/ && ./configure
 	@node defines.js
 	


### PR DESCRIPTION
I removed this, and it still installed just fine, on tested on (arch)linux and on osx.

Following from @jsedisct1's comment https://github.com/paixaop/node-sodium/issues/52#issuecomment-131356621

This makes it much easier to install my application which uses node-sodium, which makes it easier for people to use it and for devs to contribute to it.