### PR TITLE
configure travis to test node@4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "0.10"
   - "0.11"
   - "0.12"
+  - 4
 branches:
   only:
     - master


### PR DESCRIPTION
added travis config for node@4.

This doesn't seem to build for me (only a problem on travis though) it seems to complain about not having a C++11 compiler.

Also
* do you need to have your email address hardcoded in the travis config? this makes it awkward to test forks on travis, I don't want to be spamming you with travis emails.
* why does it do `make configure` before install? shouldn't it be exactly the same as a normal install?