### PR TITLE
travis-ci: test on node@4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,18 @@ node_js:
   - "0.11"
   - "0.12"
   -  4
+
+env:
+  - CXX=g++-4.8
+
 addons:
   apt:
     sources:
-    - ubuntu-toolchain-r-test
+      - ubuntu-toolchain-r-test
     packages:
-    - gcc-4.8
-    - g++-4.8
-    - clang
+      - g++-4.8
+
+before_install:
+  - export JOBS=max
+  - export prebuild_compile=true
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,5 @@ node_js:
   - "0.10"
   - "0.11"
   - "0.12"
-branches:
-  only:
-    - master
-    - develop
-notifications:
-  email:
-    - paixaop@gmail.com
-script: npm test
-before_install:
-  - make configure
+  -  4
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ node_js:
   - "0.11"
   - "0.12"
   -  4
-compiler:
-  - gcc
-  - clang
-install:
-- if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,20 @@
+sudo: false
 language: node_js
 node_js:
   - "0.10"
   - "0.11"
   - "0.12"
   -  4
-
+compiler:
+  - gcc
+  - clang
+install:
+- if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - gcc-4.8
+    - g++-4.8
+    - clang


### PR DESCRIPTION
this adds travis coverage for node@4,
this requires gcc+4.8,
I have copied the travis configuration from leveldown, and got this working on all recent node versions.

(I have removed make configure and the hardcoding to your email - is this required? I still get emails about my repos without a hard coded address)