### PR TITLE
Change should to assert in KeyPair

### DIFF
--- a/lib/keys/keypair.js
+++ b/lib/keys/keypair.js
@@ -106,8 +106,9 @@ module.exports = function KeyPair() {
      * @returns {boolean} true is both public and secret keys are valid
      */
     self.isValid = function(keys, encoding) {
-        keys.should.have.type('object');
-        keys.should.have.properties('publicKey', 'secretKey');
+        assert.equal(typeof keys, 'object');
+        assert.ok(keys.publicKey);
+        assert.ok(keys.secretKey);
 
         encoding = encoding || self.defaultEncoding;
 
@@ -166,7 +167,7 @@ module.exports = function KeyPair() {
      * @param encoding {String} optional. If v is a string you can specify the encoding
      */
     self.set = function(keys, encoding) {
-        keys.should.have.type('object');
+        assert.equal(typeof keys, 'object');
 
         if( keys instanceof KeyPair ) {
             self.secretKey.set(keys.sk(), encoding);


### PR DESCRIPTION
This fixes:

```
TypeError: Cannot read property 'have' of undefined
```

This happens when attempting to generate a new signing keypair:

```
const sodium = require('sodium')
const key = new sodium.Key.Sign('bQj0WS5mn7jiqE+ha690l+yFb2EdyjL/mrFNqCW7AnM=',
  'gzuOUlTzw3WvjWsl7NxI9iSWilw3BOHlWzXGVkLo4GNtCPRZL' +
  'mafuOKoT6Frr3SX7IVvYR3KMv+asU2oJbsCcw==', 
  'base64')
```