### PR TITLE
fixed libsodium build

### DIFF
--- a/.dntrc
+++ b/.dntrc
@@ -6,6 +6,6 @@ OUTPUT_PREFIX="sodium-"
 TEST_CMD="\
   cd /dnt/ && \
   npm install && \
-  node_modules/.bin/node-gyp --nodedir /usr/src/node/ rebuild && \
+  node-gyp --nodedir /usr/src/node/ rebuild && \
   make test; \
 "

--- a/.gitignore
+++ b/.gitignore
@@ -158,7 +158,6 @@ deps/libsodium/testing
 .libs
 Build
 INSTALL
-Makefile
 Makefile.in
 aclocal.m4
 autom4te.cache
@@ -166,7 +165,6 @@ build
 compile
 confdefs.h
 config.*
-configure
 configure.lineno
 coverage.info
 depcomp
@@ -174,7 +172,7 @@ android-toolchain
 install-sh
 libtool
 libsodium.pc
-libsodium-*
+libsodium-*.pc
 ltmain.sh
 m4/argz.m4
 m4/libtool.m4

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ ec:
 libsodium:
 ifeq (,$(wildcard ${STATIC_LIB}.*))
 	@echo Static libsodium was not found at ${STATIC_LIB} so compiling libsodium from source.
-	@cd $(LIBSODIUM_DIR)/ && aclocal && libtoolize --force && automake --add-missing && autoconf
+	@cd $(LIBSODIUM_DIR)/ && ./autogen.sh
 	@cd $(LIBSODIUM_DIR)/ && ./configure --enable-static \
            --enable-shared --with-pic --prefix="$(INSTALL_DIR)"
 	@cd $(LIBSODIUM_DIR)/ && make clean > /dev/null

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,9 @@ ec:
 libsodium:
 ifeq (,$(wildcard ${STATIC_LIB}.*))
 	@echo Static libsodium was not found at ${STATIC_LIB} so compiling libsodium from source.
-	@cd $(LIBSODIUM_DIR)/ && ./configure  \
-		--enable-static --enable-shared --with-pic --prefix="$(INSTALL_DIR)"
+	@cd $(LIBSODIUM_DIR)/ && aclocal && libtoolize --force && automake --add-missing && autoconf
+	@cd $(LIBSODIUM_DIR)/ && ./configure --enable-static \
+           --enable-shared --with-pic --prefix="$(INSTALL_DIR)"
 	@cd $(LIBSODIUM_DIR)/ && make clean > /dev/null
 	@cd $(LIBSODIUM_DIR)/ && make -j3 check
 	@cd $(LIBSODIUM_DIR)/ && make -j3 install
@@ -71,7 +72,7 @@ else
 endif
 
 sodium: libsodium
-	$(BINDIR)/node-gyp rebuild
+	node-gyp rebuild
 
 test: test-unit
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "license": "MIT",
   "description": "Lib Sodium port for node.js",
   "dependencies": {
-    "node-gyp": "^3.3.1",
     "mdextract": "^1.0.0",
     "nan": "^2.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "description": "Lib Sodium port for node.js",
   "dependencies": {
+    "node-gyp": "^3.3.1",
     "mdextract": "^1.0.0",
     "nan": "^2.2.1"
   },


### PR DESCRIPTION
*Disclaimer:* I have no idea what I'm doing.

`Makefile` has to be included in the release, so I removed it from `.gitignore`. There are also irrelevant entries in `.gitignore`, but I did not touch them.

~~`node-gyp` will be always called during `make sodium`, so I added it to dependencies. This should also ensure that `node-gyp` will be always called from local `node_modules` during install.~~

This pull request is supposed to fix Issue #74.