### PR TITLE
Update not implemented functions

### DIFF
--- a/docs/not implemented.md
+++ b/docs/not implemented.md
@@ -11,6 +11,8 @@ If you really need them please create a pull request and I will merge it in. Tha
   * sodium_mprotect_readonly
   * sodium_mprotect_readwrite
   * sodium_munlock
+  * crypto_box_seal
+  * crypto_box_seal_open
   
 Deprecated Functions
   


### PR DESCRIPTION
Added note about missing crypto_box_seal and crypto_box_seal_open functions. [Source](https://download.libsodium.org/libsodium/content/public-key_cryptography/sealed_boxes.html)

If I looked over it and didn't see it, I'm sorry please ignore me. 