### PR TITLE
correct buffer lengths, and error messages

### DIFF
--- a/src/crypto_sign_ed25519.cc
+++ b/src/crypto_sign_ed25519.cc
@@ -27,7 +27,7 @@ NAN_METHOD(bind_crypto_sign_ed25519_pk_to_curve25519) {
     ARGS(1, "argument ed25519_pk must be a buffer")
     ARG_TO_UCHAR_BUFFER_LEN(ed25519_pk, crypto_sign_ed25519_PUBLICKEYBYTES);
     
-    NEW_BUFFER_AND_PTR(curve25519_pk, crypto_sign_curve25519_PUBLICKEYBYTES);
+    NEW_BUFFER_AND_PTR(curve25519_pk, crypto_box_PUBLICKEYBYTES);
 
     if( crypto_sign_ed25519_pk_to_curve25519(curve25519_pk_ptr, ed25519_pk) != 0) {
       return Nan::ThrowError("crypto_sign_ed25519_pk_to_curve25519 conversion failed");
@@ -56,7 +56,7 @@ NAN_METHOD(bind_crypto_sign_ed25519_sk_to_curve25519) {
     ARGS(1, "argument ed25519_sk must be a buffer");
     ARG_TO_UCHAR_BUFFER_LEN(ed25519_sk, crypto_sign_ed25519_SECRETKEYBYTES);
     
-    NEW_BUFFER_AND_PTR(curve25519_sk, crypto_sign_curve25519_SECRETKEYBYTES);
+    NEW_BUFFER_AND_PTR(curve25519_sk, crypto_box_SECRETKEYBYTES);
 
     if( crypto_sign_ed25519_sk_to_curve25519(curve25519_sk_ptr, ed25519_sk) != 0) {
       return Nan::ThrowError("crypto_sign_ed25519_sk_to_curve25519 conversion failed");

--- a/src/crypto_sign_ed25519.cc
+++ b/src/crypto_sign_ed25519.cc
@@ -56,7 +56,7 @@ NAN_METHOD(bind_crypto_sign_ed25519_sk_to_curve25519) {
     ARGS(1, "argument ed25519_sk must be a buffer");
     ARG_TO_UCHAR_BUFFER_LEN(ed25519_sk, crypto_sign_ed25519_SECRETKEYBYTES);
     
-    NEW_BUFFER_AND_PTR(curve25519_sk, crypto_box_SECRETKEYBYTES);
+    NEW_BUFFER_AND_PTR(curve25519_sk, crypto_scalarmult_curve25519_BYTES);
 
     if( crypto_sign_ed25519_sk_to_curve25519(curve25519_sk_ptr, ed25519_sk) != 0) {
       return Nan::ThrowError("crypto_sign_ed25519_sk_to_curve25519 conversion failed");

--- a/src/crypto_sign_ed25519.cc
+++ b/src/crypto_sign_ed25519.cc
@@ -27,7 +27,7 @@ NAN_METHOD(bind_crypto_sign_ed25519_pk_to_curve25519) {
     ARGS(1, "argument ed25519_pk must be a buffer")
     ARG_TO_UCHAR_BUFFER_LEN(ed25519_pk, crypto_sign_ed25519_PUBLICKEYBYTES);
     
-    NEW_BUFFER_AND_PTR(curve25519_pk, crypto_sign_ed25519_PUBLICKEYBYTES);
+    NEW_BUFFER_AND_PTR(curve25519_pk, crypto_sign_curve25519_PUBLICKEYBYTES);
 
     if( crypto_sign_ed25519_pk_to_curve25519(curve25519_pk_ptr, ed25519_pk) != 0) {
       return Nan::ThrowError("crypto_sign_ed25519_pk_to_curve25519 conversion failed");
@@ -56,10 +56,10 @@ NAN_METHOD(bind_crypto_sign_ed25519_sk_to_curve25519) {
     ARGS(1, "argument ed25519_sk must be a buffer");
     ARG_TO_UCHAR_BUFFER_LEN(ed25519_sk, crypto_sign_ed25519_SECRETKEYBYTES);
     
-    NEW_BUFFER_AND_PTR(curve25519_sk, crypto_sign_ed25519_SECRETKEYBYTES);
+    NEW_BUFFER_AND_PTR(curve25519_sk, crypto_sign_curve25519_SECRETKEYBYTES);
 
     if( crypto_sign_ed25519_sk_to_curve25519(curve25519_sk_ptr, ed25519_sk) != 0) {
-      return Nan::ThrowError("crypto_sign_ed25519_pk_to_curve25519 conversion failed");
+      return Nan::ThrowError("crypto_sign_ed25519_sk_to_curve25519 conversion failed");
     }
     
     return info.GetReturnValue().Set(curve25519_sk);


### PR DESCRIPTION
return the correct length of secret key for `crypto_sign_ed25519_sk_to_curve25519`,
and also fix error messages which had been copypasted incorrectly

https://github.com/paixaop/node-sodium/commit/805b6f521db3f5049b4e961a6304b8b2ded63eec#commitcomment-19350734
