### PR TITLE
Output buffer arg not required

### DIFF
--- a/src/crypto_pwhash.cc
+++ b/src/crypto_pwhash.cc
@@ -42,7 +42,7 @@ NAN_METHOD(bind_crypto_pwhash_argon2i) {
 NAN_METHOD(bind_crypto_pwhash_argon2i_str) {
     Nan::EscapableHandleScope scope;
     
-    ARGS(3,"arguments must be: output buffer, password buffer, oLimit, memLimit");
+    ARGS(3,"arguments must be: password buffer, oLimit, memLimit");
     
     ARG_TO_BUFFER_TYPE(passwd, char*);
     ARG_TO_NUMBER(oppLimit);

--- a/src/crypto_pwhash.cc
+++ b/src/crypto_pwhash.cc
@@ -123,7 +123,7 @@ NAN_METHOD(bind_crypto_pwhash) {
 NAN_METHOD(bind_crypto_pwhash_str) {
     Nan::EscapableHandleScope scope;
     
-    ARGS(3,"arguments must be: output buffer, password buffer, oLimit, memLimit");
+    ARGS(3,"arguments must be: password buffer, oLimit, memLimit");
     
     ARG_TO_BUFFER_TYPE(passwd, char*);
     ARG_TO_NUMBER(oppLimit);
@@ -210,7 +210,7 @@ NAN_METHOD(bind_crypto_pwhash_scryptsalsa208sha256) {
 NAN_METHOD(bind_crypto_pwhash_scryptsalsa208sha256_ll) {
     Nan::EscapableHandleScope scope;
 
-    ARGS(6,"arguments must be: password buffer, salt buffer, N, r, p");
+    ARGS(6,"arguments must be: password buffer, salt buffer, N, r, p, output buffer");
     
     ARG_TO_BUFFER_TYPE(passwd, uint8_t*);
     ARG_TO_BUFFER_TYPE(salt, uint8_t*);


### PR DESCRIPTION
Just fixes an error message: the output buffer is not required for `pwhash_crypto_argon2i_str` (there should be only three arguments).