### PR TITLE
The randombytes_random and randombytes_uniform should return unsigned…

### DIFF
--- a/src/randombytes.cc
+++ b/src/randombytes.cc
@@ -46,7 +46,7 @@ NAN_METHOD(bind_randombytes_random) {
 
     // uint_32 randombytes_random()
     return info.GetReturnValue().Set(
-        Nan::New<Int32>(randombytes_random())
+        Nan::New<Uint32>(randombytes_random())
     );
 }
 
@@ -64,7 +64,7 @@ NAN_METHOD(bind_randombytes_uniform) {
 
     // uint32_t randombytes_uniform(const uint32_t upper_bound)
     return info.GetReturnValue().Set(
-        Nan::New<Int32>(randombytes_uniform(upper_bound))
+        Nan::New<Uint32>(randombytes_uniform(upper_bound))
     );
 }
 


### PR DESCRIPTION
… int values.

Hi,

Shouldn't [randombytes_random](https://github.com/paixaop/node-sodium/blob/master/docs/low-level-api.md#randombytes_random) and [randombytes_uniform](https://github.com/paixaop/node-sodium/blob/master/docs/low-level-api.md#randombytes_uniformupperbound) return unsigned int values?

Thank you for the library :).
