### PR TITLE
Address issue #101 -- crypto_pwhash_str returns an ascii string

### DIFF
--- a/src/crypto_pwhash.cc
+++ b/src/crypto_pwhash.cc
@@ -48,9 +48,9 @@ NAN_METHOD(bind_crypto_pwhash_argon2i_str) {
     ARG_TO_NUMBER(oppLimit);
     ARG_TO_NUMBER(memLimit);
     
-    NEW_BUFFER_AND_PTR(out, crypto_pwhash_argon2i_STRBYTES); 
-    
-    if (crypto_pwhash_argon2i_str((char*)out_ptr, passwd, passwd_size, oppLimit, memLimit) == 0) {
+    char buf[crypto_pwhash_argon2i_STRBYTES];
+    if (crypto_pwhash_argon2i_str(buf, passwd, passwd_size, oppLimit, memLimit) == 0) {
+        Local<v8::String> out = Nan::New<String>( buf ).ToLocalChecked();
         return info.GetReturnValue().Set(out);
     }
     
@@ -65,11 +65,10 @@ NAN_METHOD(bind_crypto_pwhash_argon2i_str_verify) {
     Nan::EscapableHandleScope scope;
 
     ARGS(2,"arguments must be: pwhash string, password");
-    
-    ARG_TO_UCHAR_BUFFER_LEN(hash, crypto_pwhash_argon2i_STRBYTES);
+    String::Utf8Value hash(info[_arg]->ToString()); _arg++;
     ARG_TO_BUFFER_TYPE(passwd, char*);
     
-    if (crypto_pwhash_argon2i_str_verify((char*)hash, passwd, passwd_size) == 0) {
+    if (crypto_pwhash_argon2i_str_verify((char*)(*hash), passwd, passwd_size) == 0) {
         return info.GetReturnValue().Set(Nan::True());
     }
     
@@ -129,9 +128,9 @@ NAN_METHOD(bind_crypto_pwhash_str) {
     ARG_TO_NUMBER(oppLimit);
     ARG_TO_NUMBER(memLimit);
     
-    NEW_BUFFER_AND_PTR(out, crypto_pwhash_STRBYTES); 
-    
-    if (crypto_pwhash_str((char*)out_ptr, passwd, passwd_size, oppLimit, memLimit) == 0) {
+    char buf[crypto_pwhash_STRBYTES];
+    if (crypto_pwhash_str(buf, passwd, passwd_size, oppLimit, memLimit) == 0) {
+        Local<v8::String> out = Nan::New<String>( buf ).ToLocalChecked();
         return info.GetReturnValue().Set(out);
     }
     
@@ -151,10 +150,10 @@ NAN_METHOD(bind_crypto_pwhash_str_verify) {
 
     ARGS(2,"arguments must be: pwhash string, password");
     
-    ARG_TO_UCHAR_BUFFER_LEN(hash, crypto_pwhash_STRBYTES);
+    String::Utf8Value hash(info[_arg]->ToString()); _arg++;
     ARG_TO_BUFFER_TYPE(passwd, char*);
     
-    if (crypto_pwhash_str_verify((char*)hash, passwd, passwd_size) == 0) {
+    if (crypto_pwhash_str_verify((char*)(*hash), passwd, passwd_size) == 0) {
         return info.GetReturnValue().Set(Nan::True());
     }
     
@@ -244,10 +243,10 @@ NAN_METHOD(bind_crypto_pwhash_scryptsalsa208sha256_str) {
     ARG_TO_NUMBER(oppLimit);
     ARG_TO_NUMBER(memLimit);
     
-    NEW_BUFFER_AND_PTR(hash, crypto_pwhash_scryptsalsa208sha256_STRBYTES);
-    
-    if (crypto_pwhash_scryptsalsa208sha256_str((char*)hash_ptr, passwd, passwd_size, oppLimit, memLimit) == 0) {
-        return info.GetReturnValue().Set(hash);
+    char buf[crypto_pwhash_scryptsalsa208sha256_STRBYTES];
+    if (crypto_pwhash_scryptsalsa208sha256_str(buf, passwd, passwd_size, oppLimit, memLimit) == 0) {
+        Local<v8::String> out = Nan::New<String>( buf ).ToLocalChecked();
+        return info.GetReturnValue().Set(out);
     }
     
     return info.GetReturnValue().Set(Nan::Null());
@@ -263,10 +262,10 @@ NAN_METHOD(bind_crypto_pwhash_scryptsalsa208sha256_str_verify) {
 
     ARGS(2,"arguments must be: pwhash string, password");
     
-    ARG_TO_UCHAR_BUFFER_LEN(hash, crypto_pwhash_scryptsalsa208sha256_STRBYTES);
+    String::Utf8Value hash(info[_arg]->ToString()); _arg++;
     ARG_TO_BUFFER_TYPE(passwd, char*);
     
-    if (crypto_pwhash_scryptsalsa208sha256_str_verify((char*)hash, passwd, passwd_size) == 0) {
+    if (crypto_pwhash_scryptsalsa208sha256_str_verify((char*)(*hash), passwd, passwd_size) == 0) {
         return info.GetReturnValue().Set(Nan::True());
     }
     

--- a/test/test_crypto_pwhash_issue101.js
+++ b/test/test_crypto_pwhash_issue101.js
@@ -1,0 +1,43 @@
+const assert = require('assert');
+const sodium = require('../build/Release/sodium');
+
+describe('pwhash_str', function() {
+    it('the generated hash should be a string containing no nulls', function(done) {
+        var password = Buffer.from('this is a test password','utf8');
+    
+        var out = sodium.crypto_pwhash_str(
+                    password,
+                    sodium.crypto_pwhash_OPSLIMIT_INTERACTIVE,
+                    sodium.crypto_pwhash_MEMLIMIT_INTERACTIVE);
+	assert.equal(typeof out, 'string');
+	assert.equal(out.indexOf('\0'), -1 );
+        
+        done();
+    });
+});
+    
+describe('pwhash_argon2i_str', function() {
+    it('the generated hash should be a string containing no nulls', function(done) {
+        var password = Buffer.from('this is a test password','utf8');
+        var out = sodium.crypto_pwhash_argon2i_str(
+                    password,
+                    sodium.crypto_pwhash_argon2i_OPSLIMIT_INTERACTIVE,
+                    sodium.crypto_pwhash_argon2i_MEMLIMIT_INTERACTIVE);
+	assert.equal(typeof out, 'string');
+	assert.equal(out.indexOf('\0'), -1 );
+        done();
+    });
+});
+
+describe('PWHash scryptsalsa208sha256', function() {
+    it('the generated hash should be a string containing no nulls', function(done) {
+        var password = Buffer.from('this is a test password','utf8');
+        var out = sodium.crypto_pwhash_scryptsalsa208sha256_str(
+                    password,
+                    sodium.crypto_pwhash_scryptsalsa208sha256_OPSLIMIT_INTERACTIVE,
+                    sodium.crypto_pwhash_scryptsalsa208sha256_MEMLIMIT_INTERACTIVE);
+	assert.equal(typeof out, 'string');
+	assert.equal(out.indexOf('\0'), -1 );
+        done();
+    });
+});


### PR DESCRIPTION
Previously, crypto_pwhash_str and friends used Buffers for the hash return value / argument, but the hash was a plain ascii string with trailing null characters. Now crypto_pwhash_str returns an ascii string with no null characters and _str_verify accepts such a string (or a buffer, as before).

I adjusted all 3 variants and added a test to check for string output with no null characters.

I didn't see node_sodium.h macros for string arguments, so I used Nan / V8. I immediately convert the "string" argument to a string, so I don't think there is much to worry about.