### PR TITLE
Don't buffer build output

### DIFF
--- a/install.js
+++ b/install.js
@@ -271,8 +271,8 @@ function doDownloads(next) {
     });
 }
 
-function run(cmdLine, expectedExitCode, next) {
-    var child = spawn(cmdLine, { shell: true });
+function run(cmdLine, args, expectedExitCode, next) {
+    var child = spawn(cmdLine, args);
 
     if (typeof expectedExitCode === 'undefined') {
         expectedExitCode = 0;
@@ -341,9 +341,9 @@ function isPreInstallMode() {
 // Start
 if (os.platform() !== 'win32') {
     if (isPreInstallMode()) {
-        run('make libsodium');
+        run('make', ['libsodium']);
     } else {
-        run('make nodesodium');
+        run('make', ['nodesodium']);
     }
 } else {
     checkMSVSVersion();
@@ -358,7 +358,7 @@ if (os.platform() !== 'win32') {
         });
     } else {
         console.log('Install Mode');
-        run('node-gyp rebuild', 0, function() {
+        run('node-gyp', ['rebuild'], 0, function() {
             console.log('Copy lib files to Release folder');
             files = libFiles.slice(0); // clone array
             copyFiles(files, function() {

--- a/install.js
+++ b/install.js
@@ -10,6 +10,7 @@ var https = require('https');
 var fs = require('fs');
 var path = require('path');
 var exec = require('child_process').exec;
+var spawn = require('child_process').spawn;
 var os = require('os');
 
 var libFiles = [
@@ -271,7 +272,7 @@ function doDownloads(next) {
 }
 
 function run(cmdLine, expectedExitCode, next) {
-    var child = exec(cmdLine);
+    var child = spawn(cmdLine, { shell: true });
 
     if (typeof expectedExitCode === 'undefined') {
         expectedExitCode = 0;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "description": "Lib Sodium port for node.js",
   "dependencies": {
-    "nan": "2.2.1"
+    "nan": "^2.2.1"
   },
   "devDependencies": {
     "mdextract": "^1.0.0",


### PR DESCRIPTION
This is a better fix for the nan version upgrade problem (https://github.com/paixaop/node-sodium/issues/124). I submitted an earlier PR which "solved" the issue by fixing the version in packages.json (https://github.com/paixaop/node-sodium/pull/125). However, I have since found the root cause of the problem (https://github.com/nodejs/nan/issues/716).

It turns out that with nan 2.8.0, the node-sodium build process prints out so many warnings that `child_process.exec` reaches max buffer size, causing `node-gyp rebuild` to be terminated! Since the buffered output is not actually used, this PR solves the issue by replacing `exec` with `spawn`. Having nan 2.8.0 as a dependency now works fine.