### PR TITLE
use Nan::ForceSet instead of obj->ForceSet

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "description": "Lib Sodium port for node.js",
   "dependencies": {
-    "nan": "2.2.1"
+    "nan": ">=2.2.1"
   },
   "devDependencies": {
     "mdextract": "^1.0.0",

--- a/src/crypto_aead.cc
+++ b/src/crypto_aead.cc
@@ -323,8 +323,8 @@ NAN_METHOD(bind_crypto_aead_aes256gcm_encrypt_detached_afternm) {
 
     if( crypto_aead_aes256gcm_encrypt_detached_afternm(c_ptr, mac_ptr, NULL, m, m_size, ad, ad_size, NULL, npub, (crypto_aead_aes256gcm_state*)ctx) == 0 ) {
         Local<Object> result = Nan::New<Object>();
-        result->ForceSet(Nan::New<String>("cipherText").ToLocalChecked(), c, DontDelete);
-        result->ForceSet(Nan::New<String>("mac").ToLocalChecked(), mac, DontDelete);
+        Nan::ForceSet(result, Nan::New<String>("cipherText").ToLocalChecked(), c, DontDelete);
+        Nan::ForceSet(result, Nan::New<String>("mac").ToLocalChecked(), mac, DontDelete);
         return info.GetReturnValue().Set(result);
     }
 

--- a/src/crypto_box.cc
+++ b/src/crypto_box.cc
@@ -144,8 +144,8 @@ NAN_METHOD(bind_crypto_box_keypair) {
     if (crypto_box_keypair(pk_ptr, sk_ptr) == 0) {
         Local<Object> result = Nan::New<Object>();
 
-        result->ForceSet(Nan::New<String>("publicKey").ToLocalChecked(), pk, DontDelete);
-        result->ForceSet(Nan::New<String>("secretKey").ToLocalChecked(), sk, DontDelete);
+        Nan::ForceSet(result, Nan::New<String>("publicKey").ToLocalChecked(), pk, DontDelete);
+        Nan::ForceSet(result, Nan::New<String>("secretKey").ToLocalChecked(), sk, DontDelete);
 
         return info.GetReturnValue().Set(result);
     } else {
@@ -542,8 +542,8 @@ NAN_METHOD(bind_crypto_box_seed_keypair) {
     if (crypto_box_seed_keypair(pk_ptr, sk_ptr, seed) == 0) {
         Local<Object> result = Nan::New<Object>();
 
-        result->ForceSet(Nan::New<String>("publicKey").ToLocalChecked(), pk, DontDelete);
-        result->ForceSet(Nan::New<String>("secretKey").ToLocalChecked(), sk, DontDelete);
+        Nan::ForceSet(result, Nan::New<String>("publicKey").ToLocalChecked(), pk, DontDelete);
+        Nan::ForceSet(result, Nan::New<String>("secretKey").ToLocalChecked(), sk, DontDelete);
 
         return info.GetReturnValue().Set(result);
     }

--- a/src/crypto_box_curve25519xsalsa20.cc
+++ b/src/crypto_box_curve25519xsalsa20.cc
@@ -143,8 +143,8 @@ NAN_METHOD(bind_crypto_box_keypair) {
     if (crypto_box_keypair(pk_ptr, sk_ptr) == 0) {
         Local<Object> result = Nan::New<Object>();
 
-        result->ForceSet(Nan::New<String>("publicKey").ToLocalChecked(), pk, DontDelete);
-        result->ForceSet(Nan::New<String>("secretKey").ToLocalChecked(), sk, DontDelete);
+        Nan::ForceSet(result, Nan::New<String>("publicKey").ToLocalChecked(), pk, DontDelete);
+        Nan::ForceSet(result, Nan::New<String>("secretKey").ToLocalChecked(), sk, DontDelete);
 
         return info.GetReturnValue().Set(result);
     } else {

--- a/src/crypto_box_curve25519xsalsa20poly1305.cc
+++ b/src/crypto_box_curve25519xsalsa20poly1305.cc
@@ -46,8 +46,8 @@ NAN_METHOD(bind_crypto_box_curve25519xsalsa20poly1305_keypair) {
     if (crypto_box_curve25519xsalsa20poly1305_keypair(pk_ptr, sk_ptr) == 0) {
         Local<Object> result = Nan::New<Object>();
 
-        result->ForceSet(Nan::New<String>("publicKey").ToLocalChecked(), pk, DontDelete);
-        result->ForceSet(Nan::New<String>("secretKey").ToLocalChecked(), sk, DontDelete);
+        Nan::ForceSet(result, Nan::New<String>("publicKey").ToLocalChecked(), pk, DontDelete);
+        Nan::ForceSet(result, Nan::New<String>("secretKey").ToLocalChecked(), sk, DontDelete);
 
         return info.GetReturnValue().Set(result);
     } else {

--- a/src/crypto_sign_ed25519.cc
+++ b/src/crypto_sign_ed25519.cc
@@ -165,8 +165,8 @@ NAN_METHOD(bind_crypto_sign_ed25519_keypair) {
 
     if (crypto_sign_ed25519_keypair(vk_ptr, sk_ptr) == 0) {
         Local<Object> result = Nan::New<Object>();
-        result->ForceSet(Nan::New<String>("publicKey").ToLocalChecked(), vk, DontDelete);
-        result->ForceSet(Nan::New<String>("secretKey").ToLocalChecked(), sk, DontDelete);
+        Nan::ForceSet(result, Nan::New<String>("publicKey").ToLocalChecked(), vk, DontDelete);
+        Nan::ForceSet(result, Nan::New<String>("secretKey").ToLocalChecked(), sk, DontDelete);
 
         return info.GetReturnValue().Set(result);
     }
@@ -189,8 +189,8 @@ NAN_METHOD(bind_crypto_sign_ed25519_seed_keypair) {
     if (crypto_sign_ed25519_seed_keypair(vk_ptr, sk_ptr, sd) == 0) {
         Local<Object> result = Nan::New<Object>();
 
-        result->ForceSet(Nan::New<String>("publicKey").ToLocalChecked(), vk, DontDelete);
-        result->ForceSet(Nan::New<String>("secretKey").ToLocalChecked(), sk, DontDelete);
+        Nan::ForceSet(result, Nan::New<String>("publicKey").ToLocalChecked(), vk, DontDelete);
+        Nan::ForceSet(result, Nan::New<String>("secretKey").ToLocalChecked(), sk, DontDelete);
 
         return info.GetReturnValue().Set(result);
     }

--- a/src/include/crypto_aead.h
+++ b/src/include/crypto_aead.h
@@ -103,8 +103,8 @@ int crypto_aead_aes256gcm_decrypt_detached(unsigned char *m,
         unsigned long long maclen;\
         if( crypto_aead_ ## ALGO ## _encrypt_detached (c_ptr, mac_ptr, &maclen, m, m_size, ad, ad_size, NULL, npub, k) == 0 ) { \
             Local<Object> result = Nan::New<Object>(); \
-            result->ForceSet(Nan::New<String>("cipherText").ToLocalChecked(), c, DontDelete); \
-            result->ForceSet(Nan::New<String>("mac").ToLocalChecked(), mac, DontDelete); \
+            Nan::ForceSet(result, Nan::New<String>("cipherText").ToLocalChecked(), c, DontDelete); \
+            Nan::ForceSet(result, Nan::New<String>("mac").ToLocalChecked(), mac, DontDelete); \
             return info.GetReturnValue().Set(result); \
         } \
         return info.GetReturnValue().Set(Nan::Undefined()); \


### PR DESCRIPTION
This is still deprecated, but at least it compiles again.

Tested with node 9.4.0 and 9.5.0, nan 2.2.1 and 2.8.0, all on linux
x86_64. Three tests still fail: 7, 145, and 467.

Fixes: #123  (assuming the test failures are unrelated)