### PR TITLE
Rework crypto_hash_* bindings

### DIFF
--- a/src/crypto_hash.cc
+++ b/src/crypto_hash.cc
@@ -20,12 +20,8 @@ NAPI_METHOD(crypto_hash) {
     ARG_TO_UCHAR_BUFFER(msg);
 
     NEW_BUFFER_AND_PTR(hash, crypto_hash_BYTES);
-
-    if( crypto_hash(hash_ptr, msg, msg_size) == 0 ) {
-        return hash;
-    } else {
-        return env.Null();
-    }
+    THROW_IF_ERR(crypto_hash(hash_ptr, msg, msg_size));
+    return hash;
 }
 
 NAPI_METHOD_FROM_INT(crypto_hash_bytes)

--- a/src/crypto_hash_sha256.cc
+++ b/src/crypto_hash_sha256.cc
@@ -16,16 +16,12 @@
 NAPI_METHOD(crypto_hash_sha256) {
     Napi::Env env = info.Env();
 
-    ARGS(1,"argument message must be a buffer");
+    ARGS(1, "argument message must be a buffer");
     ARG_TO_UCHAR_BUFFER(msg);
 
     NEW_BUFFER_AND_PTR(hash, crypto_hash_sha256_BYTES);
-
-    if( crypto_hash_sha256(hash_ptr, msg, msg_size) == 0 ) {
-        return hash;
-    }
-
-    return env.Null();
+    THROW_IF_ERR(crypto_hash_sha256(hash_ptr, msg, msg_size));
+    return hash;
 }
 
 /*
@@ -35,12 +31,8 @@ NAPI_METHOD(crypto_hash_sha256_init) {
     Napi::Env env = info.Env();
 
     NEW_BUFFER_AND_PTR(state, crypto_hash_sha256_statebytes());
-
-    if( crypto_hash_sha256_init((crypto_hash_sha256_state*) state_ptr) == 0 ) {
-        return state;
-    }
-
-    return env.Null();
+    THROW_IF_ERR(crypto_hash_sha256_init((crypto_hash_sha256_state*) state_ptr));
+    return state;
 }
 
 /* int crypto_hash_sha256_update(crypto_hash_sha256_state *state,
@@ -53,18 +45,12 @@ NAPI_METHOD(crypto_hash_sha256_init) {
 NAPI_METHOD(crypto_hash_sha256_update) {
     Napi::Env env = info.Env();
 
-    ARGS(2,"arguments must be two buffers: hash state, message part");
-    ARG_TO_UCHAR_BUFFER(state); // VOID
+    ARGS(2, "arguments must be two buffers: hash state, message part");
+    ARG_TO_UCHAR_BUFFER_LEN(state, crypto_hash_sha256_statebytes());
     ARG_TO_UCHAR_BUFFER(msg);
 
-    NEW_BUFFER_AND_PTR(state2, crypto_hash_sha256_statebytes());
-    memcpy(state2_ptr, state, crypto_hash_sha256_statebytes());
-
-    if( crypto_hash_sha256_update((crypto_hash_sha256_state*)state2_ptr, msg, msg_size) == 0 ) {
-        return state2;
-    }
-
-    return env.Null();
+    THROW_IF_ERR(crypto_hash_sha256_update((crypto_hash_sha256_state*)state, msg, msg_size));
+    return env.Undefined();
 }
 
 NAPI_METHOD_FROM_INT(crypto_hash_sha256_bytes)
@@ -76,15 +62,12 @@ NAPI_METHOD_FROM_INT(crypto_hash_sha256_bytes)
 NAPI_METHOD(crypto_hash_sha256_final) {
     Napi::Env env = info.Env();
 
-    ARGS(1,"arguments must be a hash state buffer");
-    ARG_TO_UCHAR_BUFFER(state);  // VOID
+    ARGS(1, "arguments must be a hash state buffer");
+    ARG_TO_UCHAR_BUFFER_LEN(state, crypto_hash_sha256_statebytes());
+
     NEW_BUFFER_AND_PTR(hash, crypto_hash_sha256_BYTES);
-
-    if( crypto_hash_sha256_final((crypto_hash_sha256_state*)state, hash_ptr) == 0 ) {
-        return hash;
-    }
-
-    return Napi::Boolean::New(env, false);
+    THROW_IF_ERR(crypto_hash_sha256_final((crypto_hash_sha256_state*)state, hash_ptr))
+    return hash;
 }
 
 /**

--- a/src/crypto_hash_sha512.cc
+++ b/src/crypto_hash_sha512.cc
@@ -16,16 +16,12 @@
 NAPI_METHOD(crypto_hash_sha512) {
     Napi::Env env = info.Env();
 
-    ARGS(1,"argument message must be a buffer");
+    ARGS(1, "argument message must be a buffer");
     ARG_TO_UCHAR_BUFFER(msg);
 
     NEW_BUFFER_AND_PTR(hash, crypto_hash_sha512_BYTES);
-
-    if( crypto_hash_sha512(hash_ptr, msg, msg_size) == 0 ) {
-        return hash;
-    }
-
-    return env.Null();
+    THROW_IF_ERR(crypto_hash_sha512(hash_ptr, msg, msg_size));
+    return hash;
 }
 
 /*
@@ -35,12 +31,8 @@ NAPI_METHOD(crypto_hash_sha512_init) {
     Napi::Env env = info.Env();
 
     NEW_BUFFER_AND_PTR(state, crypto_hash_sha512_statebytes());
-
-    if( crypto_hash_sha512_init((crypto_hash_sha512_state*) state_ptr) == 0 ) {
-        return state;
-    }
-
-    return env.Null();
+    THROW_IF_ERR(crypto_hash_sha512_init((crypto_hash_sha512_state*) state_ptr));
+    return state;
 }
 
 /* int crypto_hash_sha512_update(crypto_hash_sha512_state *state,
@@ -53,18 +45,12 @@ NAPI_METHOD(crypto_hash_sha512_init) {
 NAPI_METHOD(crypto_hash_sha512_update) {
     Napi::Env env = info.Env();
 
-    ARGS(2,"arguments must be two buffers: hash state, message part");
-    ARG_TO_UCHAR_BUFFER(state);  // VOID
+    ARGS(2, "arguments must be two buffers: hash state, message part");
+    ARG_TO_UCHAR_BUFFER_LEN(state, crypto_hash_sha512_statebytes());
     ARG_TO_UCHAR_BUFFER(msg);
 
-    NEW_BUFFER_AND_PTR(state2, crypto_hash_sha512_statebytes());
-    memcpy(state2_ptr, state, crypto_hash_sha512_statebytes());
-
-    if( crypto_hash_sha512_update((crypto_hash_sha512_state*)state2_ptr, msg, msg_size) == 0 ) {
-        return state2;
-    }
-
-    return env.Null();
+    THROW_IF_ERR(crypto_hash_sha512_update((crypto_hash_sha512_state*)state, msg, msg_size));
+    return env.Undefined();
 }
 
 /* int crypto_hash_sha512_final(crypto_hash_sha512_state *state,
@@ -74,15 +60,12 @@ NAPI_METHOD(crypto_hash_sha512_update) {
 NAPI_METHOD(crypto_hash_sha512_final) {
     Napi::Env env = info.Env();
 
-    ARGS(1,"arguments must be a hash state buffer");
-    ARG_TO_UCHAR_BUFFER(state);  // VOID
-    NEW_BUFFER_AND_PTR(hash, crypto_hash_sha256_BYTES);
+    ARGS(1, "arguments must be a hash state buffer");
+    ARG_TO_UCHAR_BUFFER_LEN(state, crypto_hash_sha512_statebytes());
 
-    if( crypto_hash_sha512_final((crypto_hash_sha512_state*) state, hash_ptr) == 0 ) {
-        return hash;
-    }
-
-    return env.Null();
+    NEW_BUFFER_AND_PTR(hash, crypto_hash_sha512_BYTES);
+    THROW_IF_ERR(crypto_hash_sha512_final((crypto_hash_sha512_state*)state, hash_ptr))
+    return hash;
 }
 
 NAPI_METHOD_FROM_INT(crypto_hash_sha512_bytes)
@@ -92,7 +75,6 @@ NAPI_METHOD_FROM_INT(crypto_hash_sha512_bytes)
  */
 void register_crypto_hash_sha512(Napi::Env env, Napi::Object exports) {
 
-    // Hash
     EXPORT(crypto_hash_sha512);
     EXPORT(crypto_hash_sha512_init);
     EXPORT(crypto_hash_sha512_update);

--- a/src/include/node_sodium.h
+++ b/src/include/node_sodium.h
@@ -185,6 +185,11 @@
         return Napi::String::New(env, NAME()); \
     }
 
+#define THROW_IF_ERR(ERR) \
+    if ( (ERR) != 0 ) { \
+        Napi::Error::New(env, "libsodium call failed").ThrowAsJavaScriptException(); \
+        return env.Undefined(); \
+    }
 
 #define NAPI_METHOD_KEYGEN(NAME) \
     NAPI_METHOD(NAME ## _keygen) { \

--- a/test/test_crypto_hash.js
+++ b/test/test_crypto_hash.js
@@ -8,47 +8,110 @@ var sodium = require('../build/Release/sodium');
 var crypto = require('crypto');
 
 describe('Hash', function() {
-    it('should return sha hash', function(done) {
-        var buf = Buffer.alloc(100, 1);
-        var r = sodium.crypto_hash(buf);
-        var hashString = r.toString('hex');
-        assert.equal(hashString, "ceacfdb0944ac37da84556adaac97bbc9a0190ae8ca091576b91ca70e134d1067da2dd5cc311ef147b51adcfbfc2d4086560e7af1f580db8bdc961d5d7a1f127");
-        assert.equal(hashString, crypto.createHash('sha512').update(buf).digest('hex'));
-        done();
-    });
+    const testVectors = [
+        {
+            description: 'empty',
+            input: Buffer.alloc(0),
+            chunkedInputs: [
+                [Buffer.alloc(0), Buffer.alloc(0)],
+                [Buffer.alloc(0), Buffer.alloc(0), Buffer.alloc(0)],
+            ],
+            expectedOutput: {
+                sha256: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+                sha512: 'cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e',
+            },
+        },
+        {
+            description: 'ASCII "abc"',
+            input: Buffer.from('abc', 'ascii'),
+            chunkedInputs: [
+                [Buffer.from('', 'ascii'), Buffer.from('abc', 'ascii')],
+                [Buffer.from('abc', 'ascii'), Buffer.from('', 'ascii')],
+                [Buffer.from('a', 'ascii'), Buffer.from('bc', 'ascii')],
+            ],
+            expectedOutput: {
+                sha256: 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+                sha512: 'ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f',
+            },
+        },
+        {
+            description: 'ASCII "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"',
+            input: Buffer.from('abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu', 'ascii'),
+            chunkedInputs: [],
+            expectedOutput: {
+                sha256: 'cf5b16a778af8380036ce59e7b0492370b249b11e8f07a51afac45037afee9d1',
+                sha512: '8e959b75dae313da8cf4f72814fc143f8f7779c6eb9f7fa17299aeadb6889018501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909',
+            },
+        },
+        {
+            description: 'byte 0x01 repeated 1 million times',
+            input: Buffer.alloc(1000000, 0x01),
+            chunkedInputs: [
+                [Buffer.alloc(999999, 0x01), Buffer.alloc(1, 0x01)],
+                [Buffer.alloc(100000, 0x01), Buffer.alloc(500000, 0x01), Buffer.alloc(400000, 0x01)],
+            ],
+            expectedOutput: {
+                sha256: '1fb6a051d8996888485d47fea0007a88e1e78ea273fa5fb60e1ab00608dbb764',
+                sha512: '1a32b7c186fac5b7492c2fc74a081382b05c07e6adb30e583a25f16053e55fdbba0dbce00449c70554a12be6f8a57244bb4115f6b21a705e27d94c862b3be86a',
+            },
+        },
+    ];
 
-    it('should calculate same hash as the crypto module', function(done) {
-        var buf = Buffer.alloc(100, 1);
-        var r = sodium.crypto_hash(buf);
-        var hashString = r.toString('hex');
-        assert.equal(hashString, crypto.createHash('sha512').update(buf).digest('hex'));
-        done();
-    });
+    for (const testVector of testVectors) {
+        it('crypto_hash_sha256 should handle input ' + testVector.description, function(done) {
+            const expectedOutput = testVector.expectedOutput.sha256;
 
-    it('should return sha512', function(done) {
-        var buf = Buffer.alloc(100, 1);
-        var r = sodium.crypto_hash_sha512(buf);
-        var hashString = r.toString('hex');
-        assert.equal(hashString, "ceacfdb0944ac37da84556adaac97bbc9a0190ae8ca091576b91ca70e134d1067da2dd5cc311ef147b51adcfbfc2d4086560e7af1f580db8bdc961d5d7a1f127");
-        done();
-    });
+            // Sanity check to make sure Node crypto matches our expected output.
+            const nodeCryptoOutput = crypto.createHash('sha256').update(testVector.input).digest('hex');
+            assert.equal(nodeCryptoOutput, expectedOutput);
 
-    it('should calculate same hash as the crypto module', function(done) {
-        var buf = Buffer.alloc(100, 1);
-        var r = sodium.crypto_hash_sha256(buf);
-        var hashString = r.toString('hex');
-        assert.equal(hashString, crypto.createHash('sha256').update(buf).digest('hex'));
-        done();
-    });
+            const oneShotOutput = sodium.crypto_hash_sha256(testVector.input).toString('hex');
+            assert.equal(oneShotOutput, expectedOutput);
+
+            for (const chunkedInput of testVector.chunkedInputs) {
+                const state = sodium.crypto_hash_sha256_init();
+                for (const chunk of chunkedInput) {
+                    sodium.crypto_hash_sha256_update(state, chunk);
+                }
+                const multiShotOutput = sodium.crypto_hash_sha256_final(state).toString('hex');
+                assert.equal(multiShotOutput, expectedOutput);
+            }
+            done();
+        });
+
+        it('crypto_hash_sha512 should handle input ' + testVector.description, function(done) {
+            const expectedOutput = testVector.expectedOutput.sha512;
+
+            // Sanity check to make sure Node crypto matches our expected output.
+            const nodeCryptoOutput = crypto.createHash('sha512').update(testVector.input).digest('hex');
+            assert.equal(nodeCryptoOutput, expectedOutput);
+
+            const oneShotOutput = sodium.crypto_hash_sha512(testVector.input).toString('hex');
+            assert.equal(oneShotOutput, expectedOutput);
+
+            const aliasOneShotOutput = sodium.crypto_hash(testVector.input).toString('hex');
+            assert.equal(aliasOneShotOutput, expectedOutput);
+
+            for (const chunkedInput of testVector.chunkedInputs) {
+                const state = sodium.crypto_hash_sha512_init();
+                for (const chunk of chunkedInput) {
+                    sodium.crypto_hash_sha512_update(state, chunk);
+                }
+                const multiShotOutput = sodium.crypto_hash_sha512_final(state).toString('hex');
+                assert.equal(multiShotOutput, expectedOutput);
+            }
+            done();
+        });
+    }
 });
 
 describe('crypto_hash_sha512 verify parameters', function() {
     it('bad param 1', function(done) {
-         assert.throws(function() {
+        assert.throws(function() {
             var r = sodium.crypto_hash_sha512("buf");
         });
 
-         assert.throws(function() {
+        assert.throws(function() {
             var r = sodium.crypto_hash_sha512(1);
         });
         done();
@@ -57,11 +120,11 @@ describe('crypto_hash_sha512 verify parameters', function() {
 
 describe('crypto_hash_sha verify parameters', function() {
     it('bad param 1', function(done) {
-         assert.throws(function() {
+        assert.throws(function() {
             var r = sodium.crypto_hash_sha("buf");
         });
 
-         assert.throws(function() {
+        assert.throws(function() {
             var r = sodium.crypto_hash_sha(1);
         });
         done();
@@ -70,11 +133,11 @@ describe('crypto_hash_sha verify parameters', function() {
 
 describe('crypto_hash_sha256 verify parameters', function() {
     it('bad param 1', function(done) {
-         assert.throws(function() {
+        assert.throws(function() {
             var r = sodium.crypto_hash_sha256("buf");
         });
 
-         assert.throws(function() {
+        assert.throws(function() {
             var r = sodium.crypto_hash_sha256(1);
         });
         done();


### PR DESCRIPTION
**If underlying call fails, throw.**  Since failure is rare, and there's usually nothing the caller can do about it, I think an exception is better than a return value.  This is a backwards-incompatible change, unfortunately.

**Reuse state buffer instead of making a copy.**  The existing bindings made a copy of the state buffer on every `update()`.  Not sure why.

**Add tests for the init/update/final mode of operation.**  There weren't any tests for the init/update/final mode of operation and I believe it wasn't working correctly (#141).  Things seem to work after these changes, but I didn't actually track down the bug in the original code.