### PR TITLE
fix unhelpful log message with wrong MSVS version

### DIFF
--- a/install.js
+++ b/install.js
@@ -309,7 +309,7 @@ function errorSetMSVSVersion() {
 }
 
 function errorInvalidMSVSVersion() {
-    console.log('Invalid msvs_version ' + msvsVersion + '\n');
+    console.log('Invalid msvs_version ' + process.env.npm_config_msvs_version + '\n');
     console.log('Please set your Microsoft Visual Studio version before you run npm install');
     console.log('Example for Visual Studio 2015:\n');
     console.log('    For you user only:\n');


### PR DESCRIPTION
Closes #147

Right now it would crash with this error, instead of returning the helpful message about setting msvs to a different version.

```javascript
    console.log('Invalid msvs_version ' + msvsVersion + '\n');
                                          ^

ReferenceError: msvsVersion is not defined
```